### PR TITLE
添加nuitka打包支持

### DIFF
--- a/buildlinux-nuitka.sh
+++ b/buildlinux-nuitka.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+
+nuitka3 --standalone --onefile --enable-plugin=tk-inter  \
+ --follow-imports -include-package-data=pywebio binpython.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tornado
 xlrd
 wget
 requests
+Nuitka==1.6.1


### PR DESCRIPTION
使用pyinstaller打包binpython，如果打包binpython的Linux的主机和需要执行binpython的目标主机的glibc版本不一致，会导致binpython无法执行，测试在docker容器openEuler（openEuler release 22.03 (LTS-SP1)，glibc版本2.34）上使用nuitka（Nuitka==1.6.1）打包，可以拷贝到wsl（ubuntu22.04，glibc2.35）上执行